### PR TITLE
Creating basic S3 class for estimators (lm and otherwise)

### DIFF
--- a/R/regr.R
+++ b/R/regr.R
@@ -16,12 +16,21 @@
 #' regr(mpg ~ wt + disp*cyl)
 #'
 #' @export
-regr <- function(formula) { # TODO accept arguments for robust/cluster and level
-  model <- stats::lm(formula, data = .get("dataset"))
-  .set("model", model)
-  print(summary(model)) # TODO quick and dirty, use class behavior
+regr <- function(formula) {
+  lm_fit <- stats::lm(formula, data = .get("dataset"))
 
-  invisible(NULL)
+  # TODO add options for level and vcov type
+  model <- rstata_estimator(
+    estimates = lm_fit$coefficients,
+    vcov = sandwich::vcovHC(lm_fit, type = "HC0"),
+    level = 95
+  )
+
+  .set("model", model)
+
+  # return this out in case the user wants it. Otherwise it will just invoke print.rstata_estimator,
+  # which will give us the nice coefficient table that we want.
+  model
 }
 
 #' @title
@@ -37,4 +46,4 @@ regr <- function(formula) { # TODO accept arguments for robust/cluster and level
 #'
 #'
 #' @export
-b_ <- function(v) stats::coef(.get("model"))[deparse(substitute(v))]
+b_ <- function(v) .get("model")$estimates[deparse(substitute(v))]

--- a/R/regr.R
+++ b/R/regr.R
@@ -46,4 +46,4 @@ regr <- function(formula) {
 #'
 #'
 #' @export
-b_ <- function(v) .get("model")$estimates[deparse(substitute(v))]
+b_ <- function(v) stats::coef(.get("model"))[deparse(substitute(v))]

--- a/R/rstata_estimator.R
+++ b/R/rstata_estimator.R
@@ -1,0 +1,12 @@
+# this is a class representation of estimators that just stores a point estimate, covariance matrix, and alpha level.
+# from there you can reproduce the p-values and confidence intervals like stata
+rstata_estimator <- function(estimates, vcov, level) {
+  structure(
+    list(
+      estimates = estimates,
+      vcov = vcov,
+      level = level
+    ),
+    class = "rstata_estimator"
+  )
+}

--- a/R/rstata_estimator.R
+++ b/R/rstata_estimator.R
@@ -10,3 +10,6 @@ rstata_estimator <- function(estimates, vcov, level) {
     class = "rstata_estimator"
   )
 }
+
+coef.rstata_estimator <- function(m) m$estimates
+vcov.rstata_estimator <- function(m) m$vcov

--- a/R/testnl.R
+++ b/R/testnl.R
@@ -67,7 +67,7 @@ testnl <- function(...) {
 
   # use delta method to get covariance matrix of our functions
   grad <- gradient(fs)
-  V <- grad %*% sandwich::vcovHC(model, type = "HC1") %*% t(grad)
+  V <- grad %*% stats::vcov(model) %*% t(grad)
 
 
   chisq_stat <- X %*% solve(V) %*% t(X)


### PR DESCRIPTION
Added S3 methods to vcov and coef so that we can use standard R programming procedures (rather than relying on internal model structure). Had to amend testnl and regr to accommodate.

closes #1 